### PR TITLE
fix LastIndexOf bug

### DIFF
--- a/GC Free String/gstring.cs
+++ b/GC Free String/gstring.cs
@@ -900,7 +900,7 @@ namespace System
             while(true)
             {
                 idx = internal_index_of(this._value, value, idx + value.Length);
-				last_find = idx;
+                last_find = idx;
                 if (idx == -1 || idx + value.Length >= this._value.Length)
                     break;
             }
@@ -914,7 +914,7 @@ namespace System
             while(true)
             {
                 idx = internal_index_of(this._value, value, idx + 1);
-				last_find = idx;
+                last_find = idx;
                 if (idx == -1 || idx + 1 >= this._value.Length)
                     break;
             }

--- a/GC Free String/gstring.cs
+++ b/GC Free String/gstring.cs
@@ -900,9 +900,9 @@ namespace System
             while(true)
             {
                 idx = internal_index_of(this._value, value, idx + value.Length);
-                if (idx == -1 || idx + value.Length > this._value.Length)
+				last_find = idx;
+                if (idx == -1 || idx + value.Length >= this._value.Length)
                     break;
-                last_find = idx;
             }
             return last_find;
         }
@@ -914,9 +914,9 @@ namespace System
             while(true)
             {
                 idx = internal_index_of(this._value, value, idx + 1);
-                if (idx == -1 || idx + 1 > this._value.Length)
+				last_find = idx;
+                if (idx == -1 || idx + 1 >= this._value.Length)
                     break;
-                last_find = idx;
             }
             return last_find;
         }


### PR DESCRIPTION
gstr.LastIndexOf(pattern)
it appears when pattern lies exactly at the end of gstr, an index-out-of-range error will occur.
